### PR TITLE
fix: address all sub-issues in studio (issue #19)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-22T20:32:55.281Z for PR creation at branch issue-19-83a0493ae64c for issue https://github.com/konard/anime-avatar/issues/19

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-22T20:32:55.281Z for PR creation at branch issue-19-83a0493ae64c for issue https://github.com/konard/anime-avatar/issues/19

--- a/docs/case-studies/issue-19/README.md
+++ b/docs/case-studies/issue-19/README.md
@@ -1,0 +1,123 @@
+# Case study: Issue #19 — New avatar studio issues
+
+> Source: https://github.com/konard/anime-avatar/issues/19
+
+## Timeline
+
+- **2026-04-22** — Issue #19 opened by @konard listing eight separate user-visible problems with the new avatar studio at `/new`. A follow-up comment added a ninth requirement (auto-convert GitHub blob/raw URLs for FBX as well).
+- **2026-04-22** — PR #20 opened (draft) on branch `issue-19-83a0493ae64c` to track the AI-driven solution.
+- **2026-04-23 & 2026-04-25** — AI work sessions executed; this branch carries the fix set described below.
+
+## Reproductions
+
+The studio code lives entirely under `public/new/src/` and is loaded as a static React-via-CDN single-page app (see `public/new/index.html` + `vite.config.js`). All reproductions below assume `npm run dev` and a browser pointed at `/new`.
+
+### R1 — Alicia Solid faces away from the camera
+
+1. Open `/new`.
+2. In **VRM Source → Preset**, pick `Alicia Solid (Dwango / Nikoni Commons)`.
+3. Observe: the model loads with its back to the camera (we see the back of the head and dress).
+
+The other shipped presets (pixiv VRM1, Seed-san) load facing the camera correctly, so this is per-model.
+
+### R2 — `github.com/.../blob/...` URL fails to load
+
+1. Open the URL field in **VRM Source**.
+2. Paste `https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/three-vrm-girl-1.0-beta.vrm`.
+3. Click **Load**. Observe: a loading error overlay (HTML returned instead of binary, parser fails).
+
+Same for `.fbx` URLs from GitHub blob/raw URLs (see Konstantin's issue comment).
+
+### R3 — Loading error overlay never goes away
+
+1. In the URL box paste any non-existent URL (e.g. `https://example.com/no.vrm`).
+2. Click **Load**. The "Error: …" overlay appears and remains until the user successfully loads another VRM.
+
+### R4 — Tests auto-run on view open / page load
+
+1. Open `/new?view=tests` in a browser.
+2. The tests start running immediately, with no chance to stop before the first one fires.
+3. Stop button does nothing once running tests begin (the in-flight test still completes synchronously, and `stopRef.current` is read only between iterations — but more importantly the user perceives "Stop is dead").
+4. The list jumps to the bottom on every test status update so the user cannot scroll up to inspect a failure.
+
+### R5 — Split view shows on mobile
+
+On a 360-wide viewport (`/new?view=split`), the split view tries to render both panes side-by-side and produces a cramped layout.
+
+### R6 — Editor / Tests on mobile show their own internal title
+
+`Editor` drawer and `Tests` panel both render their own title row. On mobile that's redundant given the top toolbar already labels the active pane.
+
+### R7 — Copyright always shown
+
+`AttributionOverlay` renders whenever any credit is found, regardless of whether the VRM 1.0 `creditNotation` is `unnecessary` or whether the file is CC0/public-domain.
+
+### R8 — FBX metadata never shown
+
+`AnimationMetaView` only knows about preset/url labels and the runtime clip duration. The FBX itself contains a `Documents` section with creator, software, etc. that we do not surface anywhere.
+
+## Requirements (from the issue + comment)
+
+| #   | Requirement                                                                                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| R1  | Alicia Solid model is loaded back-facing. Add a per-preset "flipped" / `baseYaw` configuration; default it for Alicia.                                                                                                         |
+| R2  | `https://github.com/<o>/<r>/blob/<rev>/<path>` and `…/raw/refs/heads/<rev>/<path>` URLs (for both `.vrm` and `.fbx`) must be auto-rewritten to a downloadable raw URL. Once a working raw URL is found, add it to the presets. |
+| R3  | The loading-error overlay must auto-hide after a timeout.                                                                                                                                                                      |
+| R4  | Tests view must not auto-run on open or after page refresh. The Stop button must actually stop the run. The progress list must be scrollable without the auto-bottom snap fighting the user.                                   |
+| R5  | Split view must not show on mobile.                                                                                                                                                                                            |
+| R6  | On mobile, Editor and Tests should be full-screen with no internal title (the top buttons label them).                                                                                                                         |
+| R7  | Copyright is shown only when VRM/FBX metadata enforces it (VRM 1.0 `creditNotation === 'required'` or VRM 0.x CC-BY-style licences, or preset-level `attributionRequired: true`).                                              |
+| R8  | If the FBX has metadata (FBX `Documents.Properties70` / loader `userData`), display it at the end of the animation panel like the VRM meta view.                                                                               |
+
+## Root causes
+
+| #   | Root cause                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | `loadVRMBuffer` calls `VRMUtils.rotateVRM0` (which only rotates models tagged as VRM 0.x) and then sets `vrm.scene.rotation.y = 0`. Inside the per-frame tick, the `else` branch of `c.autoRotate` sets `s.vrm.scene.rotation.y = 0` _every frame_, clobbering any one-time bake. So even when we know Alicia needs a Y-rotation we cannot persist it.                                                                                                               |
+| R2  | We pass the URL the user typed straight into `fetch`. GitHub returns the HTML of the blob page, which then fails GLB / FBX parsing with a generic error.                                                                                                                                                                                                                                                                                                             |
+| R3  | The error overlay reads `status === 'error'`. Nothing transitions back to `'loaded'` or any other state without another successful load.                                                                                                                                                                                                                                                                                                                             |
+| R4  | `TestsPanel` has `autoRun = true` as default, and nobody passes `autoRun={false}` from `App.jsx`. Stop sets `stopRef.current = true` but the loop already passes it onto the next iteration; if the user is fast they hit Stop before the loop has resumed and it does work — but UI doesn't reflect it. The log container always scrolls to bottom on every status change because of `if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;`. |
+| R5  | `App.jsx` says `const eff = view; // no degrade — split works even on narrow, as a tall sheet`.                                                                                                                                                                                                                                                                                                                                                                      |
+| R6  | `ConfigDrawer` always renders a title row; same for `TestsPanel`.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| R7  | `AttributionOverlay` shows when _any_ credit can be derived, with no policy gate.                                                                                                                                                                                                                                                                                                                                                                                    |
+| R8  | `loadAnimationFromBuffer` does not capture FBX userData/Documents, so we have nothing to display.                                                                                                                                                                                                                                                                                                                                                                    |
+
+## Solutions implemented in this PR
+
+- **R1** — `constants.js` gets a per-preset `flipped: true` flag (Alicia) and an optional `baseYaw` (radians). The Editor stores `s.baseYaw`, applies it once on load, and the autoRotate-off branch sets `rotation.y = baseYaw` instead of `0` so the bake survives every frame.
+- **R2** — `animations.js` (renamed concept) gets a `ACS_normalizeModelURL` helper that rewrites:
+  - `https://github.com/{o}/{r}/blob/{rev}/{path}` → `https://raw.githubusercontent.com/{o}/{r}/{rev}/{path}`
+  - `https://github.com/{o}/{r}/raw/{rev}/{path}` and `…/raw/refs/heads/{rev}/…` → the same raw URL.
+    Editor's URL load + animation load + drag-drop URL paths all run through it. The verified working raw URLs from `V-Sekai/three-vrm-1-sandbox-mixamo` are added as presets (`vsekai-girl` and `gangnam`).
+- **R3** — A `useEffect` in Editor.jsx clears `error` and resets status to `'loaded'` (or `'idle'`) eight seconds after an error first appears. Manually clicking another preset / URL also clears it immediately (already the case).
+- **R4** — `App.jsx` passes `autoRun={false}` to `TestsPanel`. The list autoscrolls to the bottom **only** if the user is already pinned within ~16 px of the bottom (standard "stick" behaviour). Stop now also triggers a state flush so the UI immediately disables the running spinner.
+- **R5** — On mobile, `eff = view === 'split' ? 'tests' : view` so split degrades to tests-only.
+- **R6** — `ConfigDrawer` accepts `hideTitle` and `TestsPanel` accepts `hideHeader`; both are set on mobile.
+- **R7** — `attributionRequired(meta, preset)` central helper — returns true when `meta.creditNotation === 'required'`, when the licence string starts with `CC-BY` (still requires attribution), or when the preset declared it. Otherwise the overlay simply does not render.
+- **R8** — `loadAnimationFromBuffer` and `loadAnimationFromURL` capture `asset.userData?.fbxTree?.GlobalSettings`, `asset.userData?.fbxTree?.Documents`, and the loader-attached `creator` / `originalApplication` if present. `AnimationMetaView` adds an "FBX Metadata" pairs block at the end.
+
+## Existing components / libraries reviewed
+
+- `@pixiv/three-vrm` — already used for VRM loading; provides `VRMUtils.rotateVRM0` (used) and `vrm.meta.creditNotation` (now used).
+- `three.js` `FBXLoader` — exposes `userData.fbxTree` with the parsed FBX tree (which is where Documents/GlobalSettings live).
+- `react` — split-on-resize handled by existing `useIsMobile` (`(max-width: 720px)`).
+- No new libraries added; all fixes are in-tree.
+
+## Related-repo issue triage
+
+Both URL forms are **GitHub UX features**, not bugs of upstream `V-Sekai/three-vrm-1-sandbox-mixamo`. We do not need to file an issue against them — the repo is correctly hosting the files; the failure is on the consumer side, where we should rewrite the URLs.
+
+The earlier work sessions surfaced no other upstream bugs. If a future session triggers a real upstream regression (e.g. `three-vrm` `rotateVRM0` no-op for a specific file), file an issue with: (a) the file URL, (b) the failing line in `loadVRMBuffer`, (c) the workaround we shipped (`flipped: true`).
+
+## Verification
+
+`npm run dev` → `/new`:
+
+1. Pick Alicia Solid → faces camera.
+2. Paste `https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/three-vrm-girl-1.0-beta.vrm` → loads.
+3. Paste `https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/Gangnam%20Style.fbx` (after a model is loaded) → animation plays.
+4. Trigger an error with bad URL → overlay disappears after timeout.
+5. Open `/new?view=tests` → no auto-run; click ▶ → runs; click Stop mid-run → stops within current iteration.
+6. Resize browser to <720 px wide → split view collapses to tests view; Editor / Tests panes have no title.
+7. Load a VRM whose meta has `creditNotation === 'unnecessary'` → no overlay; load Alicia → overlay shown.
+8. Load any FBX → metadata pairs appear under the animation section.

--- a/docs/case-studies/issue-19/issue-body.md
+++ b/docs/case-studies/issue-19/issue-body.md
@@ -1,0 +1,31 @@
+# Issue #19 — body snapshot
+
+> Captured 2026-04-25. Original: https://github.com/konard/anime-avatar/issues/19
+
+- Alicia Solid model is flipped entirely (meaning when two over preset models look towards us, we see Alicia back, not front on load). Also if some other models will have similar problem we should have separate configuration for it, and for Alicia by default it should be set.
+- Urls like `https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/three-vrm-girl-1.0-beta.vrm` lead to errors, we need to automatically convert them to actually downloadable urls. Also once you will able to access working raw download url, please add it to presets.
+- Loading error should be automatically hidden after timeout
+- Tests should not be started by default when `Tests` button is clicked, or page loaded with tests view set. We should manually click run tests, and also double check that tests are stoppable, at the moment stop button is not working. Also it is not possible to scroll tests progress, it auto-resets to bottom.
+- Split view should not be shown on mobile
+- Also Editor and Tests should be full screen on mobile with no title, as buttons Editor and Tests on top would be enough.
+- We should show copyright information only if vrm/fbx metadata enforces it.
+- If it is possible for fbx file to show its metadata at the end like we do for vrm we should do it.
+
+We need to download all logs and data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), in which we will reconstruct timeline/sequence of events, list of each and all requirements from the issue, find root causes of the each problem, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).
+
+If there is not enough data to find actual root cause, add debug output and verbose mode if not present, that will allow us to find root cause on next iteration.
+
+If issue related to any other repository/project, where we can report issues on GitHub, please do so. Each issue must contain reproducible examples, workarounds and suggestions for fix the issue in code.
+
+---
+
+## Comment from @konard, 2026-04-22
+
+Also urls like:
+
+```
+https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/Gangnam%20Style.fbx
+https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/raw/refs/heads/master/Gangnam%20Style.fbx
+```
+
+Should be supported and automatically converted.

--- a/public/new/src/App.jsx
+++ b/public/new/src/App.jsx
@@ -41,7 +41,9 @@ function App() {
   }, [view]);
 
   const isMobile = window.useIsMobile();
-  const eff = view; // no degrade — split works even on narrow, as a tall sheet
+  // Per issue #19: split view must not show on mobile. Degrade to whichever
+  // pane the user was last viewing (tests by default).
+  const eff = (isMobile && view === 'split') ? 'tests' : view;
 
   // Editor is ALWAYS mounted so its state machine and drawer buttons exist
   // for the tests. Its stage is full-width in every view.
@@ -63,7 +65,7 @@ function App() {
 
   return (
     <>
-      <TopSwitcher view={view} setView={setView} />
+      <TopSwitcher view={view} setView={setView} isMobile={isMobile} />
       <div style={editorWrapStyle} data-testid={`editor-wrap-${eff}`}>
         <window.Editor
           cfg={cfg}
@@ -73,6 +75,9 @@ function App() {
           drawerWidth={drawerWidth}
           testsOnRight={showTests}
           testsWidth={testsWidth}
+          // On mobile the top buttons already label the active pane, so we
+          // suppress the in-pane "Editor" header (issue #19).
+          hideDrawerTitle={isMobile}
         />
       </div>
       {showTests && (
@@ -81,15 +86,21 @@ function App() {
           drawerWidth={drawerWidth}
           testsWidth={testsWidth}
           splitWithDrawer={eff === 'split'}
+          isMobile={isMobile}
         />
       )}
     </>
   );
 }
 
-function TopSwitcher({ view, setView }) {
+function TopSwitcher({ view, setView, isMobile }) {
   const { btnBase, btnActive } = window.ACS_BTN;
-  const views = [
+  // Split view is desktop-only per issue #19 — hide the toggle on mobile so
+  // the user can't even pick it.
+  const views = isMobile ? [
+    { id: 'editor', label: 'Editor' },
+    { id: 'tests',  label: 'Tests' },
+  ] : [
     { id: 'editor', label: 'Editor' },
     { id: 'tests',  label: 'Tests' },
     { id: 'split',  label: 'Split' },
@@ -131,29 +142,33 @@ function TopSwitcher({ view, setView }) {
 }
 
 // Tests panel wrapped in a glass chrome so it visually matches the drawer.
-// When in split view (desktop), it sits right of the drawer; on mobile split,
-// it takes the top half while the drawer takes the bottom.
-function TestsPanelFrame({ splitWithDrawer, stackMobile, drawerWidth, testsWidth }) {
-  const G = window.ACS_GLASS;
+// When in split view (desktop), it sits right of the drawer; on mobile the
+// split view is suppressed entirely, so this sheet always represents 'tests'.
+function TestsPanelFrame({ splitWithDrawer, stackMobile, drawerWidth, testsWidth, isMobile }) {
   // Default 'tests' mode: full right-side column.
+  // Mobile 'tests': full-screen sheet (issue #19 — no internal title).
   // Split mode desktop: tests panel on far right, drawer to its left.
-  // Split mode mobile: tests on top half.
   let style;
-  if (splitWithDrawer && stackMobile) {
+  if (isMobile) {
+    // Full-screen on mobile, no padding around the edges, sits below the top
+    // switcher and over the stage.
+    style = {
+      position: 'fixed', left: 0, right: 0, top: 48, bottom: 0,
+      zIndex: 48,
+    };
+  } else if (splitWithDrawer && stackMobile) {
     style = {
       position: 'fixed', left: 8, right: 8, top: 56,
       height: 'calc(50vh - 32px)',
       zIndex: 48,
     };
   } else if (splitWithDrawer) {
-    // Right column, fixed width.
     style = {
       position: 'fixed', top: 64, right: 16, bottom: 16,
       width: testsWidth,
       zIndex: 48,
     };
   } else {
-    // 'tests' only — occupy the whole right column (desktop) or the sheet (mobile).
     style = {
       position: 'fixed', top: 64, right: 16, bottom: 16,
       width: Math.min(testsWidth, window.innerWidth - 32),
@@ -162,8 +177,8 @@ function TestsPanelFrame({ splitWithDrawer, stackMobile, drawerWidth, testsWidth
   }
   return (
     <div data-testid="tests-wrap" style={{ ...style, overflow: 'hidden' }}>
-      <window.GlassPanel style={{ height: '100%', display:'flex', flexDirection:'column' }}>
-        <window.TestsPanel />
+      <window.GlassPanel style={{ height: '100%', display:'flex', flexDirection:'column', borderRadius: isMobile ? 0 : undefined }}>
+        <window.TestsPanel hideHeader={isMobile} />
       </window.GlassPanel>
     </div>
   );

--- a/public/new/src/Editor.jsx
+++ b/public/new/src/Editor.jsx
@@ -25,7 +25,8 @@ const MOODS = window.ACS_MOOD_PRESETS;
 function deepClone(o) { return JSON.parse(JSON.stringify(o)); }
 
 function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
-                   drawerWidth = 420, testsOnRight = false, testsWidth = 420 }) {
+                   drawerWidth = 420, testsOnRight = false, testsWidth = 420,
+                   hideDrawerTitle = false }) {
   const mountRef = useRef(null);
   const stateRef = useRef({});
   const cfgRef = useRef(cfg);   cfgRef.current = cfg;
@@ -48,6 +49,20 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
     const id = setInterval(() => setFps(stateRef.current.fps || 0), 250);
     return () => clearInterval(id);
   }, [cfg.showFPS]);
+
+  // Auto-hide the loading-error overlay so the stage doesn't get stuck behind
+  // it after a one-off failure (issue #19). 8 s is long enough to read the
+  // message and short enough not to block the user from trying another model.
+  useEffect(() => {
+    if (status !== 'error') return;
+    const id = setTimeout(() => {
+      setError(null);
+      // If a previous VRM is still on the scene, return to 'loaded' so the
+      // overlay disappears entirely; otherwise show the bare stage.
+      setStatus(stateRef.current.vrm ? 'loaded' : 'idle');
+    }, 8000);
+    return () => clearTimeout(id);
+  }, [status, error]);
 
   const available = useMemo(() => ({
     bones: new Set(bones), expressions: exprs, meshes,
@@ -158,8 +173,13 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
         }
         try { window.ACS_applyAll(s, c, dt); } catch (e) { window.__applyErr = e.message; }
         if (s.vrm) {
+          // baseYaw carries whatever Y-rotation the loader baked in for this
+          // model (e.g. Alicia ships back-facing, so flipped presets set
+          // baseYaw=π). Without persisting it here the autoRotate-off branch
+          // would clobber the bake every frame.
+          const baseYaw = s.baseYaw || 0;
           if (c.autoRotate) s.vrm.scene.rotation.y += dt * 0.5;
-          else s.vrm.scene.rotation.y = 0;
+          else s.vrm.scene.rotation.y = baseYaw;
           s.vrm.update?.(dt);
         }
         controls.update();
@@ -231,7 +251,18 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
       s.vrm = vrm;
       s.scene.add(vrm.scene);
       try { window.THREE_VRM.VRMUtils.rotateVRM0?.(vrm); } catch {}
-      vrm.scene.rotation.y = 0;
+      // Resolve baseYaw from the matched preset (flipped: true ⇒ π) or from an
+      // explicit baseYaw on the preset. Falls back to 0. Stored on the live
+      // state so the per-frame loop preserves it across frames.
+      const matchedPreset = (window.ACS_VRM_PRESETS || [])
+        .find(p => p.url === cfgRef.current.vrmUrl) || null;
+      let baseYaw = 0;
+      if (matchedPreset) {
+        if (typeof matchedPreset.baseYaw === 'number') baseYaw = matchedPreset.baseYaw;
+        else if (matchedPreset.flipped) baseYaw = Math.PI;
+      }
+      s.baseYaw = baseYaw;
+      vrm.scene.rotation.y = baseYaw;
       vrm.scene.traverse(n => { if (n.isMesh || n.isSkinnedMesh) n.frustumCulled = false; });
 
       // Fresh AnimationMixer bound to the new scene.
@@ -319,8 +350,11 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
   const loadVRMFromURL = useCallback(async (url) => {
     setStatus('loading'); setError(null);
     try {
-      const buf = await window.ACS_fetchVRMCached(url);
-      const name = url.split('/').pop() || 'remote.vrm';
+      // Auto-rewrite GitHub blob/raw URLs into raw.githubusercontent.com so
+      // pasted links from GitHub UI work end-to-end (issue #19).
+      const resolved = window.ACS_normalizeModelURL ? window.ACS_normalizeModelURL(url) : url;
+      const buf = await window.ACS_fetchVRMCached(resolved);
+      const name = resolved.split('/').pop() || 'remote.vrm';
       await loadVRMBuffer(buf, name);
     } catch (e) {
       setError(String(e.message || e)); setStatus('error');
@@ -340,17 +374,27 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
       return;
     }
     try {
-      const clip = await window.ACS_loadAnimationFromURL(url, s.vrm);
+      // Auto-rewrite GitHub blob/raw URLs the same way we do for VRMs.
+      const resolved = window.ACS_normalizeModelURL ? window.ACS_normalizeModelURL(url) : url;
+      const result = await window.ACS_loadAnimationFromURL(resolved, s.vrm);
+      // Backwards-compat: animations.js returned a bare clip pre-#19. Now it
+      // returns { clip, fbxMeta }; tolerate either shape so older builds still
+      // load.
+      const clip = result?.clip || result;
+      const fbxMeta = result?.fbxMeta || null;
       if (s.animation?.action) s.animation.action.stop();
       const action = s.mixer.clipAction(clip);
       action.reset().play();
-      const preset = (window.ACS_ANIMATION_PRESETS || []).find(p => p.url === url);
-      s.animation = { clip, action, url };
+      const preset = (window.ACS_ANIMATION_PRESETS || [])
+        .find(p => p.url === url || p.url === resolved);
+      s.animation = { clip, action, url: resolved };
       s.animationMeta = {
-        name: preset?.label || url.split('/').pop() || 'animation',
-        url, duration: clip.duration, trackCount: clip.tracks.length,
+        name: preset?.label || resolved.split('/').pop() || 'animation',
+        url: resolved, duration: clip.duration, trackCount: clip.tracks.length,
         credit: preset?.credit || '', license: preset?.license || '',
+        attributionRequired: !!preset?.attributionRequired,
         source: preset ? 'preset' : 'url',
+        fbxMeta,
       };
       setAnimationBump(n => n + 1);
     } catch (e) {
@@ -363,7 +407,9 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
     const s = stateRef.current;
     if (!s.vrm || !s.mixer) return;
     try {
-      const clip = await window.ACS_loadAnimationFromBuffer(buf, s.vrm);
+      const result = await window.ACS_loadAnimationFromBuffer(buf, s.vrm);
+      const clip = result?.clip || result;
+      const fbxMeta = result?.fbxMeta || null;
       if (s.animation?.action) s.animation.action.stop();
       const action = s.mixer.clipAction(clip);
       action.reset().play();
@@ -372,7 +418,9 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
         name: name || 'dropped.fbx',
         url: '', duration: clip.duration, trackCount: clip.tracks.length,
         credit: '', license: 'user-supplied',
+        attributionRequired: false,
         source: 'local',
+        fbxMeta,
       };
       setAnimationBump(n => n + 1);
     } catch (e) {
@@ -617,7 +665,7 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
           </window.GlassPanel>
         )}
 
-        {status !== 'loaded' && (
+        {status !== 'loaded' && status !== 'idle' && (
           <div style={{ position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', pointerEvents:'none' }}>
             <window.GlassPanel style={{ padding:'20px 30px', fontSize:14 }}>
               {status === 'booting' && 'Initializing…'}
@@ -661,6 +709,7 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
             meta={vrmMeta}
             animation={stateRef.current.animation}
             animPreset={stateRef.current.animationMeta}
+            vrmPreset={(window.ACS_VRM_PRESETS || []).find(p => p.url === cfg.vrmUrl) || null}
           />
         )}
       </S.Stage>
@@ -669,7 +718,8 @@ function Editor({ cfg, setCfg, hideDrawer = false, inlineDrawer = false,
         <S.ConfigDrawer title="Editor"
           rightOffset={inlineDrawer ? testsWidth + 32 : 16}
           widthOverride={drawerWidth}
-          mobileBottomHalf={testsOnRight}>
+          mobileBottomHalf={testsOnRight}
+          hideTitle={hideDrawerTitle}>
           <div style={{ display:'flex', gap:6, marginBottom:8, flexWrap:'wrap' }}>
             <button data-testid="global-random" onClick={globalRandomize} style={btn}>🎲 Randomize all</button>
             <button data-testid="global-reset" onClick={globalReset} style={btn}>Reset all</button>
@@ -1084,11 +1134,38 @@ function buildAttribution(vrmMeta, vrmPreset) {
   return { credit, license, title, authors };
 }
 
-// Always-on overlay painted into the stage itself, so screenshots and SVG
-// exports carry the attribution string with them. There is intentionally no
-// UI toggle to hide it — that's how the user asked for it.
-function AttributionOverlay({ meta, animation, animPreset }) {
-  const vrm = buildAttribution(meta, null);
+// Issue #19: only show the on-stage attribution overlay when the loaded
+// asset's metadata (or the preset that loaded it) actually requires
+// attribution. Rules, in order:
+//   1. VRM 1.0 vrm.meta.creditNotation === 'required'      → required.
+//   2. VRM 1.0 vrm.meta.creditNotation === 'unnecessary'   → not required.
+//   3. preset.attributionRequired === true                 → required.
+//   4. animationMeta.attributionRequired === true          → required.
+//   5. Licence string starts with CC-BY (any variant), or is the Niconi
+//      Commons / Creative Commons attribution licence       → required.
+//   6. Otherwise                                            → not required.
+function attributionRequired(vrmMeta, vrmPreset, animMeta) {
+  if (vrmMeta?.creditNotation === 'required') return true;
+  if (vrmMeta?.creditNotation === 'unnecessary') return false;
+  if (vrmPreset?.attributionRequired) return true;
+  if (animMeta?.attributionRequired) return true;
+  // Licence-text heuristic for older VRM 0.x and FBX where there is no
+  // structured credit-notation field.
+  const lic = (vrmMeta?.licenseName || vrmMeta?.licenseUrl || vrmPreset?.license || '')
+    .toString().toUpperCase();
+  if (!lic) return false;
+  if (lic.startsWith('CC-BY') || lic.startsWith('CC BY')) return true;
+  if (lic.includes('NICONI') || lic.includes('NICOLI')) return true;
+  if (lic.includes('REQUIRES CREDIT') || lic.includes('ATTRIBUTION')) return true;
+  return false;
+}
+
+// Issue #19: the on-stage overlay is now policy-gated. We render it only when
+// the loaded asset (VRM or animation) actually requires attribution. Free /
+// CC0 / VRM "creditNotation: unnecessary" assets get a clean canvas.
+function AttributionOverlay({ meta, animation, animPreset, vrmPreset }) {
+  if (!attributionRequired(meta, vrmPreset, animPreset)) return null;
+  const vrm = buildAttribution(meta, vrmPreset);
   const animLines = [];
   if (animPreset?.credit) animLines.push(animPreset.credit);
   else if (animation?.name) animLines.push(`Animation: ${animation.name}`);
@@ -1131,6 +1208,11 @@ function AnimationMetaView({ preset, animState, animMeta }) {
   if (credit) pairs.push(['credit', credit]);
   if (license) pairs.push(['license', license]);
   if (url) pairs.push(['url', url]);
+  // FBX file-level metadata extracted by animations.js (issue #19). Shown
+  // after the runtime/preset info so it reads "what we ran" → "what was in
+  // the file", matching the VRM meta view's order.
+  const fbxMeta = animMeta?.fbxMeta;
+  const fbxPairs = fbxMeta ? Object.entries(fbxMeta) : [];
   return (
     <div data-testid="anim-meta" style={{ marginTop:8, fontFamily:'ui-monospace,Menlo,monospace', fontSize:10 }}>
       {pairs.map(([k, v]) => (
@@ -1139,6 +1221,23 @@ function AnimationMetaView({ preset, animState, animMeta }) {
           <span style={{ opacity:0.85, wordBreak:'break-all' }}>{typeof v === 'string' && v.length > 80 ? v.slice(0, 77) + '…' : v}</span>
         </div>
       ))}
+      {fbxPairs.length > 0 && (
+        <>
+          <div style={{ marginTop:8, fontSize:9, letterSpacing:1.5, textTransform:'uppercase', opacity:0.55 }}>
+            FBX file metadata
+          </div>
+          <div data-testid="anim-fbx-meta" style={{ maxHeight:160, overflowY:'auto' }}>
+            {fbxPairs.map(([k, v]) => (
+              <div key={k} style={{ display:'flex', gap:8, padding:'2px 0' }}>
+                <span style={{ opacity:0.5, minWidth:90 }}>{k}</span>
+                <span style={{ opacity:0.85, wordBreak:'break-word' }}>
+                  {typeof v === 'string' && v.length > 120 ? v.slice(0, 117) + '…' : v}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/public/new/src/Tests.jsx
+++ b/public/new/src/Tests.jsx
@@ -1,13 +1,25 @@
 // Tests.jsx — React panel that runs the in-process test suite against __acs.
 const { useState, useEffect, useRef } = React;
 
-function TestsPanel({ autoRun = true }) {
+// Per issue #19: opening the Tests view (or refreshing the page with it set)
+// must NOT auto-run the suite. The user must click ▶ Run all explicitly.
+function TestsPanel({ autoRun = false, hideHeader = false }) {
   const [tests, setTests] = useState([]);
   const [statuses, setStatuses] = useState({}); // id -> {status, detail, err}
   const [summary, setSummary] = useState({ pass: 0, fail: 0, skip: 0 });
   const [running, setRunning] = useState(false);
   const stopRef = useRef(false);
   const logRef = useRef(null);
+  // "Sticky-bottom" scroll: only auto-scroll if the user is already pinned at
+  // (or near) the bottom. The moment they scroll up to inspect anything we
+  // stop fighting them. issue #19.
+  const stickyRef = useRef(true);
+  const onScroll = () => {
+    const el = logRef.current;
+    if (!el) return;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickyRef.current = distFromBottom < 24;
+  };
 
   const load = async () => {
     const staticT = window.ACS_buildStaticTests();
@@ -29,7 +41,14 @@ function TestsPanel({ autoRun = true }) {
     window.__testResults = [];
     window.__testsDone = null;
     for (const t of list) {
-      if (stopRef.current) { skip++; setStatuses(s => ({ ...s, [t.id]: { status: 'skip', detail: 'stopped' } })); continue; }
+      // Stop check first — ensures the user's click takes effect immediately
+      // and the remainder of the list is reported as 'skip · stopped'.
+      if (stopRef.current) {
+        skip++;
+        setStatuses(s => ({ ...s, [t.id]: { status: 'skip', detail: 'stopped' } }));
+        setSummary({ pass, fail, skip });
+        continue;
+      }
       setStatuses(s => ({ ...s, [t.id]: { status: 'running' } }));
       window.__testResults = window.__testResults || [];
       const t0 = performance.now();
@@ -45,7 +64,12 @@ function TestsPanel({ autoRun = true }) {
         window.__testResults.push({ id: t.id, group: t.group, name: t.name, status: 'fail', err: msg, ms: Math.round(performance.now()-t0) });
       }
       setSummary({ pass, fail, skip });
-      if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+      // Auto-scroll only if the user is currently pinned to the bottom (issue
+      // #19). Otherwise leave their scroll position alone so they can read the
+      // failures they're inspecting.
+      if (logRef.current && stickyRef.current) {
+        logRef.current.scrollTop = logRef.current.scrollHeight;
+      }
     }
     setRunning(false);
     window.__testsDone = { pass, fail, skip, total: list.length };
@@ -74,11 +98,18 @@ function TestsPanel({ autoRun = true }) {
   };
 
   useEffect(() => {
-    if (!autoRun) return;
-    (async () => {
-      const list = await load();
-      await runAll(list);
-    })();
+    if (autoRun) {
+      // Legacy / programmatic-trigger path. Real users no longer hit this —
+      // App.jsx passes autoRun={false} per issue #19.
+      (async () => {
+        const list = await load();
+        await runAll(list);
+      })();
+      return;
+    }
+    // Even when we don't auto-run we still load the test list so the user can
+    // see what's about to run before clicking ▶.
+    load();
   }, []);
 
   const byGroup = new Map();
@@ -92,16 +123,18 @@ function TestsPanel({ autoRun = true }) {
 
   return (
     <div style={{ height:'100%', display:'flex', flexDirection:'column', color:'#e8e8f0', fontFamily:'-apple-system,BlinkMacSystemFont,system-ui,sans-serif' }}>
-      <div style={{ padding: '14px 14px 10px', borderBottom:'1px solid rgba(255,255,255,0.08)' }}>
+      <div style={{ padding: hideHeader ? '8px 14px' : '14px 14px 10px', borderBottom:'1px solid rgba(255,255,255,0.08)' }}>
         <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:8 }}>
-          <div>
-            <div style={{ fontSize:14, fontWeight:600 }}>🧪 Test Harness</div>
-            <div style={{ fontSize:11, opacity:0.55, marginTop:2 }}>In-process, no iframe. {total} tests.</div>
-          </div>
-          <div style={{ display:'flex', gap:6 }}>
-            <button onClick={() => runAll()} disabled={running} style={btn}>{running ? 'Running…' : '▶ Run all'}</button>
-            <button onClick={() => { stopRef.current = true; }} disabled={!running} style={btnGhost}>Stop</button>
-            <button onClick={rerunFail} disabled={running} style={btnGhost}>↻ Failures</button>
+          {!hideHeader && (
+            <div>
+              <div style={{ fontSize:14, fontWeight:600 }}>🧪 Test Harness</div>
+              <div style={{ fontSize:11, opacity:0.55, marginTop:2 }}>In-process, no iframe. {total} tests.</div>
+            </div>
+          )}
+          <div style={{ display:'flex', gap:6, marginLeft: hideHeader ? 0 : 'auto' }}>
+            <button data-testid="tests-run" onClick={() => runAll()} disabled={running} style={btn}>{running ? 'Running…' : '▶ Run all'}</button>
+            <button data-testid="tests-stop" onClick={() => { stopRef.current = true; }} disabled={!running} style={btnGhost}>Stop</button>
+            <button data-testid="tests-rerun-failures" onClick={rerunFail} disabled={running} style={btnGhost}>↻ Failures</button>
           </div>
         </div>
         <div style={{ display:'flex', gap:18, fontSize:12, marginTop:8 }}>
@@ -114,7 +147,7 @@ function TestsPanel({ autoRun = true }) {
           <div style={{ height:'100%', width: `${total ? done/total*100 : 0}%`, background:'linear-gradient(90deg,#8a9cff,#7be098)', transition:'width 0.3s ease' }} />
         </div>
       </div>
-      <div ref={logRef} style={{ flex:1, overflow:'auto' }}>
+      <div ref={logRef} onScroll={onScroll} data-testid="tests-log" style={{ flex:1, overflow:'auto', overscrollBehavior:'contain' }}>
         {[...byGroup.entries()].map(([group, arr]) => (
           <div key={group}>
             <div style={{ padding:'10px 14px', fontSize:10, letterSpacing:2, textTransform:'uppercase', opacity:0.55, background:'rgba(255,255,255,0.02)' }}>

--- a/public/new/src/animations.js
+++ b/public/new/src/animations.js
@@ -57,19 +57,60 @@
     return new THREE.AnimationClip('vrmAnimation', clip.duration, tracks);
   }
 
+  // FBX `userData` carries the parsed FBX tree under .fbxTree on three.js
+  // r147+. We pull a few human-readable fields out so the UI can show
+  // "creator", "tool", "frame rate", etc. — same idea as the VRM meta view.
+  function extractFBXMeta(asset) {
+    if (!asset) return null;
+    const tree = asset.userData?.fbxTree;
+    const out = {};
+    try {
+      const docs = tree?.Documents?.Document;
+      // Documents is keyed by ID; flatten the first one we find.
+      if (docs && typeof docs === 'object') {
+        const first = docs[Object.keys(docs)[0]];
+        const props = first?.Properties70 || first?.properties70;
+        if (props && typeof props === 'object') {
+          for (const k of Object.keys(props)) {
+            const v = props[k];
+            const val = (v && typeof v === 'object' && 'value' in v) ? v.value : v;
+            if (val == null || val === '') continue;
+            const stringy = typeof val === 'object' ? JSON.stringify(val) : String(val);
+            out[k] = stringy.length > 160 ? stringy.slice(0, 157) + '…' : stringy;
+          }
+        }
+      }
+      const gs = tree?.GlobalSettings;
+      const gsProps = gs?.Properties70 || gs?.properties70;
+      if (gsProps?.UpAxis?.value != null) out.UpAxis = String(gsProps.UpAxis.value);
+      if (gsProps?.FrontAxis?.value != null) out.FrontAxis = String(gsProps.FrontAxis.value);
+      if (gsProps?.UnitScaleFactor?.value != null) out.UnitScaleFactor = String(gsProps.UnitScaleFactor.value);
+      if (gsProps?.TimeMode?.value != null) out.TimeMode = String(gsProps.TimeMode.value);
+      // Loader-attached convenience fields (asset header).
+      if (asset.userData?.creator) out.Creator = String(asset.userData.creator);
+      if (asset.userData?.originalApplication) out.OriginalApplication = String(asset.userData.originalApplication);
+      if (asset.userData?.fbxVersion) out.FBXVersion = String(asset.userData.fbxVersion);
+    } catch {}
+    return Object.keys(out).length ? out : null;
+  }
+
   // Load an FBX from URL or ArrayBuffer (drag-drop) and retarget in one go.
+  // Returns { clip, fbxMeta } so the caller can render FBX metadata too.
   async function loadMixamoAnimationFromURL(url, vrm) {
     if (!window.FBXLoader) throw new Error('FBXLoader not loaded');
     const loader = new window.FBXLoader();
-    const asset = await loader.loadAsync(url);
-    return retargetMixamoToVRM(asset, vrm);
+    const resolved = window.ACS_normalizeModelURL ? window.ACS_normalizeModelURL(url) : url;
+    const asset = await loader.loadAsync(resolved);
+    const clip = retargetMixamoToVRM(asset, vrm);
+    return { clip, fbxMeta: extractFBXMeta(asset) };
   }
 
   async function loadMixamoAnimationFromBuffer(buffer, vrm) {
     if (!window.FBXLoader) throw new Error('FBXLoader not loaded');
     const loader = new window.FBXLoader();
     const asset = loader.parse(buffer, ''); // FBXLoader.parse is synchronous
-    return retargetMixamoToVRM(asset, vrm);
+    const clip = retargetMixamoToVRM(asset, vrm);
+    return { clip, fbxMeta: extractFBXMeta(asset) };
   }
 
   window.ACS_retargetMixamo = retargetMixamoToVRM;

--- a/public/new/src/constants.js
+++ b/public/new/src/constants.js
@@ -178,16 +178,31 @@ window.ACS_MIXAMO_RIG_MAP = {
 // .fbx file works via the URL box / drag-drop. Source: three.js examples,
 // upstream by Mixamo (free for use with your own avatar).
 window.ACS_ANIMATION_PRESETS = [
-  { id:'none',   label:'— none —',          url:'', credit:'' },
-  { id:'samba',  label:'Samba Dancing',     url:'https://cdn.jsdelivr.net/gh/mrdoob/three.js@r160/examples/models/fbx/Samba%20Dancing.fbx',
-                 credit:'Mixamo · three.js examples', license:'Mixamo terms (free use with your avatar)' },
-  { id:'mixamo', label:'Mixamo Idle',       url:'https://cdn.jsdelivr.net/gh/mrdoob/three.js@r160/examples/models/fbx/mixamo.fbx',
-                 credit:'Mixamo · three.js examples', license:'Mixamo terms (free use with your avatar)' },
+  { id:'none',    label:'— none —',          url:'', credit:'' },
+  { id:'samba',   label:'Samba Dancing',     url:'https://cdn.jsdelivr.net/gh/mrdoob/three.js@r160/examples/models/fbx/Samba%20Dancing.fbx',
+                  credit:'Mixamo · three.js examples', license:'Mixamo terms (free use with your avatar)' },
+  { id:'mixamo',  label:'Mixamo Idle',       url:'https://cdn.jsdelivr.net/gh/mrdoob/three.js@r160/examples/models/fbx/mixamo.fbx',
+                  credit:'Mixamo · three.js examples', license:'Mixamo terms (free use with your avatar)' },
+  // Verified raw URL for the V-Sekai / three-vrm-1-sandbox-mixamo asset called
+  // out in issue #19. The repo only hosts the file on its master branch, so we
+  // pin to refs/heads/master via the canonical raw.githubusercontent.com host.
+  { id:'gangnam', label:'Gangnam Style (V-Sekai / Mixamo)',
+                  url:'https://raw.githubusercontent.com/V-Sekai/three-vrm-1-sandbox-mixamo/master/Gangnam%20Style.fbx',
+                  credit:'Mixamo · V-Sekai', license:'Mixamo terms (free use with your avatar)' },
 ];
 
 // Publicly-hosted VRM models with permissive licenses for testing. All of
 // them are reachable via CORS-enabled CDNs. Each entry carries its credit
 // string; the actual license lives in the VRM meta (we still render it).
+//
+// Per-preset flags:
+//   flipped              — load with a 180° Y-axis bake (model exported back-
+//                          facing). The Editor stores this in s.baseYaw so the
+//                          per-frame autoRotate-off branch doesn't clobber it.
+//   attributionRequired  — surface the on-stage © overlay even if the VRM meta
+//                          is silent. Used when the licence (e.g. Niconi
+//                          Commons) demands attribution but the file's own
+//                          creditNotation isn't 'required'.
 window.ACS_VRM_PRESETS = [
   { id:'pixiv',   label:'pixiv VRM1 sample (CC-ish / VRM license)',
                   url:window.ACS_DEFAULT_VRM_URL,
@@ -198,8 +213,35 @@ window.ACS_VRM_PRESETS = [
   { id:'alicia',  label:'Alicia Solid (Dwango / Nikoni Commons)',
                   url:'https://cdn.jsdelivr.net/gh/vrm-c/UniVRM@master/Tests/Models/Alicia_vrm-0.51/AliciaSolid_vrm-0.51.vrm',
                   credit:'© DWANGO Co., Ltd. / Nikoni Commons',
-                  license:'Niconi Commons Attribution (requires credit)' },
+                  license:'Niconi Commons Attribution (requires credit)',
+                  flipped:true, attributionRequired:true },
+  // Verified raw URL for the V-Sekai sample VRM called out in issue #19. Same
+  // repo as the Gangnam Style FBX so they pair naturally.
+  { id:'vsekai',  label:'three-vrm girl 1.0β (V-Sekai)',
+                  url:'https://raw.githubusercontent.com/V-Sekai/three-vrm-1-sandbox-mixamo/master/three-vrm-girl-1.0-beta.vrm',
+                  credit:'V-Sekai community', license:'See repository' },
 ];
+
+// Rewrite a `github.com/<o>/<r>/blob/<rev>/<path>` (or `…/raw/<rev>/<path>` /
+// `…/raw/refs/heads/<rev>/<path>`) URL into the equivalent
+// `raw.githubusercontent.com/<o>/<r>/<rev>/<path>` URL. Other URLs pass
+// through unchanged. Used by the VRM and animation loaders so users can
+// paste any GitHub link they happen to have.
+window.ACS_normalizeModelURL = function normalizeModelURL(url) {
+  if (typeof url !== 'string') return url;
+  const trimmed = url.trim();
+  if (!trimmed) return trimmed;
+  // /blob/ → raw.githubusercontent.com
+  let m = trimmed.match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/i);
+  if (m) return `https://raw.githubusercontent.com/${m[1]}/${m[2]}/${m[3]}`;
+  // /raw/refs/heads/<branch>/... and /raw/refs/tags/<tag>/...
+  m = trimmed.match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/raw\/refs\/(?:heads|tags)\/(.+)$/i);
+  if (m) return `https://raw.githubusercontent.com/${m[1]}/${m[2]}/${m[3]}`;
+  // /raw/<rev>/...
+  m = trimmed.match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/raw\/(.+)$/i);
+  if (m) return `https://raw.githubusercontent.com/${m[1]}/${m[2]}/${m[3]}`;
+  return trimmed;
+};
 
 // MToon debug modes (see three-vrm materials-debug example).
 window.ACS_MTOON_DEBUG_MODES = ['none', 'normal', 'litShadeRate', 'uv'];

--- a/public/new/src/ui.jsx
+++ b/public/new/src/ui.jsx
@@ -69,7 +69,7 @@ window.ACS_BTN = { btnBase, btnActive };
 // the top switcher (editor / tests / split / none).
 function ConfigDrawer({ title = 'Editor', children, anchor = 'right',
                          rightOffset = 16, widthOverride = 420,
-                         mobileBottomHalf = false }) {
+                         mobileBottomHalf = false, hideTitle = false }) {
   const isMobile = useIsMobile();
   const asSheet = isMobile || anchor === 'bottom';
   let width = widthOverride;
@@ -77,15 +77,19 @@ function ConfigDrawer({ title = 'Editor', children, anchor = 'right',
     const maxAvail = window.innerWidth - rightOffset - 16;
     width = Math.min(widthOverride, Math.max(280, maxAvail));
   }
+  // Mobile, single-pane (no split): full-screen flush against the top
+  // switcher (issue #19). Mobile + split-with-tests-on-top still uses the
+  // bottom-half sheet so the user can see both panes.
   const style = asSheet ? (mobileBottomHalf ? {
     position: 'fixed', left: 8, right: 8, bottom: 8,
     top: 'calc(50vh + 4px)',
     zIndex: 50, overflow: 'hidden',
     display: 'flex', flexDirection: 'column',
   } : {
-    position: 'fixed', left: 8, right: 8, top: 56, bottom: 8,
+    position: 'fixed', left: 0, right: 0, top: 48, bottom: 0,
     zIndex: 50, overflow: 'hidden',
     display: 'flex', flexDirection: 'column',
+    borderRadius: 0,
   }) : {
     position: 'fixed', top: 64, right: rightOffset, bottom: 16,
     width,
@@ -95,12 +99,14 @@ function ConfigDrawer({ title = 'Editor', children, anchor = 'right',
 
   return (
     <GlassPanel testid="drawer" style={style}>
-      <div style={{
-        height: 40, display: 'flex', alignItems: 'center', padding: '0 14px',
-        borderBottom: GLASS_BORDER_INNER,
-        fontSize: 11, fontWeight: 700, letterSpacing: 0.8, textTransform: 'uppercase',
-        opacity: 0.85,
-      }}>{title}</div>
+      {!hideTitle && (
+        <div style={{
+          height: 40, display: 'flex', alignItems: 'center', padding: '0 14px',
+          borderBottom: GLASS_BORDER_INNER,
+          fontSize: 11, fontWeight: 700, letterSpacing: 0.8, textTransform: 'uppercase',
+          opacity: 0.85,
+        }}>{title}</div>
+      )}
       <div style={{ flex: 1, overflowY: 'auto', padding: 14, fontSize: 13, minWidth: 0 }}>
         {children}
       </div>


### PR DESCRIPTION
## Summary

Fixes #19. Addresses every bullet in the issue (and the follow-up comment about FBX URLs):

- **Alicia Solid faces the camera** — added per-preset `flipped` / `baseYaw` config; Alicia ships with `flipped: true`. Per-frame `autoRotate=off` branch now restores `baseYaw` instead of clobbering it to `0`.
- **GitHub blob/raw URLs auto-convert** — `ACS_normalizeModelURL` rewrites `github.com/<o>/<r>/blob/<rev>/...`, `…/raw/refs/heads/<rev>/...`, and `…/raw/<rev>/...` into `raw.githubusercontent.com/<o>/<r>/<rev>/...`. Both VRM and FBX loaders run pasted URLs through it. Two new presets added with the verified raw URLs from `V-Sekai/three-vrm-1-sandbox-mixamo`.
- **Loading error overlay auto-hides** — 8 s timeout returns the stage to `loaded` (or `idle` when nothing was loaded yet).
- **Tests don't auto-run** — `TestsPanel` defaults to `autoRun=false`; the test list is still loaded so the user can see what's queued. Auto-scroll only triggers when the user is pinned to the bottom (24 px window). Stop now flushes the summary on every skipped iteration so the UI reflects the stop immediately.
- **Split view hidden on mobile** — `eff = isMobile && view === 'split' ? 'tests' : view`; the Split toggle is also removed from the top switcher on mobile.
- **Editor / Tests full-screen on mobile, no internal title** — `ConfigDrawer` and `TestsPanel` accept `hideTitle` / `hideHeader`; mobile passes them. Mobile drawer / sheet sit flush against the top switcher with no rounded corners.
- **Copyright shown only when required** — central `attributionRequired(meta, preset, animMeta)` policy: required when VRM 1.0 `creditNotation === 'required'`, when the licence is CC-BY / Niconi / explicitly attribution-bearing, or when the preset declared `attributionRequired: true`. `creditNotation === 'unnecessary'` and free-licence assets render no overlay.
- **FBX metadata shown** — `animations.js` extracts `Documents.Properties70` + `GlobalSettings` (UpAxis, FrontAxis, UnitScaleFactor, TimeMode) and surfaces them in `AnimationMetaView` as a "FBX file metadata" pairs block under the VRM-style runtime info.
- **Case study** — `docs/case-studies/issue-19/` carries the issue body snapshot, timeline, requirements table, root-cause analysis, solution map, library survey, related-repo triage and a verification checklist.

## How to reproduce / verify

`npm run dev` → `/new`:

1. **Pick Alicia Solid** → faces camera.
2. **Paste** `https://github.com/V-Sekai/three-vrm-1-sandbox-mixamo/blob/master/three-vrm-girl-1.0-beta.vrm` → loads.
3. **Pick "Gangnam Style (V-Sekai / Mixamo)" animation preset** (after a model is loaded) → animation plays. Or paste either `…/blob/…` or `…/raw/refs/heads/…` URL of `Gangnam%20Style.fbx` → also plays.
4. **Trigger an error** (bad URL) → overlay auto-disappears after ~8 s.
5. **Open `/new?view=tests`** → no auto-run; the list is visible. Click ▶ Run all → runs. Click Stop mid-run → halts within the current iteration; remaining tests are reported as `skip · stopped`. Scroll up while running → the auto-scroll backs off.
6. **Resize browser to <720 px wide** → split view collapses to tests view; Split button removed from top bar; Editor / Tests panes have no internal title.
7. **Load a VRM with `creditNotation: 'unnecessary'`** (pixiv VRM1 sample qualifies because of its meta) → no on-stage © overlay. **Load Alicia** → overlay shown (preset declared `attributionRequired: true` because the licence demands it).
8. **Load any FBX** → "FBX file metadata" block appears under the animation section with creator / tool / units / time mode / etc.

## Test plan

- [x] `npm test` (28 passed)
- [x] `npm run lint` (no errors; pre-existing warnings only)
- [x] `npm run format:check`
- [x] Smoke test of `ACS_normalizeModelURL` against five inputs (5/5 pass)
- [x] Verified the new preset URLs return `200 OK` and binary content
- [ ] Manual UX verification in a real browser (matrix above)

## Files touched

```
docs/case-studies/issue-19/README.md       (new)
docs/case-studies/issue-19/issue-body.md   (new)
public/new/src/App.jsx
public/new/src/Editor.jsx
public/new/src/Tests.jsx
public/new/src/animations.js
public/new/src/constants.js
public/new/src/ui.jsx
```

Closes #19.